### PR TITLE
Removed inline declarations

### DIFF
--- a/trunk/Src/core/bitvector.h
+++ b/trunk/Src/core/bitvector.h
@@ -21,9 +21,9 @@ typedef struct {
 
 bitvector *bitvector_new (uscalar_t size);
 void bitvector_free (bitvector *bv);
-inline uscalar_t bitvector_length (bitvector *bv);
-inline void bitvector_set (bitvector *bv, uscalar_t idx, bool b);
-inline bool bitvector_get (bitvector *bv, uscalar_t idx);
+uscalar_t bitvector_length (bitvector *bv);
+void bitvector_set (bitvector *bv, uscalar_t idx, bool b);
+bool bitvector_get (bitvector *bv, uscalar_t idx);
 void bitvector_resize (bitvector *bv, uscalar_t new_size);
 bitvector *bitvector_xor (bitvector *bv0, bitvector *bv1);
 bitvector *bitvector_copy (bitvector *bv);

--- a/trunk/Src/core/boolformula.c
+++ b/trunk/Src/core/boolformula.c
@@ -158,7 +158,7 @@ inline boolformula_t* boolformula_neg (boolformula_t * f){
 
 
 
-inline void add_clauses_to_boolformula(boolformula_t* ret, boolformula_t * f, lit* next_fresh){
+void add_clauses_to_boolformula(boolformula_t* ret, boolformula_t * f, lit* next_fresh){
 	int i;
 	boolformula_t* cur_neg=boolformula_literal_new(boolformula_lit_complement(*next_fresh));
 	boolformula_t* dis, *temp;

--- a/trunk/Src/core/boolformula.h
+++ b/trunk/Src/core/boolformula.h
@@ -27,33 +27,33 @@ typedef struct {
 	union data d;
 } boolformula_t;
 
-inline lit boolformula_lit_from_var (var);
-inline var boolformula_var_from_lit (lit);
-inline lit boolformula_lit_complement (lit);
-inline bool boolformula_positive_lit (lit);
+lit boolformula_lit_from_var (var);
+var boolformula_var_from_lit (lit);
+lit boolformula_lit_complement (lit);
+bool boolformula_positive_lit (lit);
 
-inline boolformula_t *boolformula_neg (boolformula_t *);
-inline boolformula_t *boolformula_disjunction_new (uscalar_t length);
-inline boolformula_t *boolformula_disjunction_unit (void);
-inline boolformula_t *boolformula_conjunction_new (uscalar_t length);
-inline boolformula_t *boolformula_conjunction_unit (void);
-inline boolformula_t *boolformula_literal_new (lit);
+boolformula_t *boolformula_neg (boolformula_t *);
+boolformula_t *boolformula_disjunction_new (uscalar_t length);
+boolformula_t *boolformula_disjunction_unit (void);
+boolformula_t *boolformula_conjunction_new (uscalar_t length);
+boolformula_t *boolformula_conjunction_unit (void);
+boolformula_t *boolformula_literal_new (lit);
 
-inline boolformula_t *boolformula_add (boolformula_t *, boolformula_t *);
-inline boolformula_t *boolformula_set (boolformula_t *, uscalar_t idx, boolformula_t *);
+boolformula_t *boolformula_add (boolformula_t *, boolformula_t *);
+boolformula_t *boolformula_set (boolformula_t *, uscalar_t idx, boolformula_t *);
 
-inline enum type boolformula_get_type (boolformula_t *);
-inline uscalar_t boolformula_get_length (boolformula_t *);
-inline boolformula_t *boolformula_get_subformula (boolformula_t *, uscalar_t idx);//for disjunct/disjunct
-inline lit boolformula_get_value (boolformula_t *);//for literal
+enum type boolformula_get_type (boolformula_t *);
+uscalar_t boolformula_get_length (boolformula_t *);
+boolformula_t *boolformula_get_subformula (boolformula_t *, uscalar_t idx);//for disjunct/disjunct
+lit boolformula_get_value (boolformula_t *);//for literal
 
 
-inline void boolformula_free (boolformula_t *);
+void boolformula_free (boolformula_t *);
 void boolformula_print (boolformula_t *f);
 scalar_t boolformula_num_of_var(boolformula_t* f);
 
-inline boolformula_t *boolformula_to_cnf (boolformula_t *, scalar_t);
-inline boolformula_t *boolformula_copy(boolformula_t *);
+boolformula_t *boolformula_to_cnf (boolformula_t *, scalar_t);
+boolformula_t *boolformula_copy(boolformula_t *);
 
 
 

--- a/trunk/Src/core/cdnfformula.c
+++ b/trunk/Src/core/cdnfformula.c
@@ -201,7 +201,7 @@ bool cdnfformula_eval_M_DNF (disjunction *m_dnf, bitvector *bv)
   return false;
 }
 
-inline boolformula_t* monomial_to_boolformula (monomial *m)
+boolformula_t* monomial_to_boolformula (monomial *m)
 {
   boolformula_t* ret=boolformula_conjunction_new(vector_length(m)),*temp;
 
@@ -214,7 +214,7 @@ inline boolformula_t* monomial_to_boolformula (monomial *m)
   return ret;
 }
 
-inline boolformula_t* dnf_to_boolformula (disjunction *f)
+boolformula_t* dnf_to_boolformula (disjunction *f)
 {
   boolformula_t* ret=boolformula_disjunction_new(vector_length(f)), *temp;
 
@@ -227,7 +227,7 @@ inline boolformula_t* dnf_to_boolformula (disjunction *f)
   return ret;
 }
 
-inline boolformula_t *cdnfformula_to_boolformula (conjunction * f){
+boolformula_t *cdnfformula_to_boolformula (conjunction * f){
   boolformula_t* ret=boolformula_conjunction_new(vector_length(f)), *temp;
   uscalar_t i;
   for (i = 0; i < vector_length (f); i++) {

--- a/trunk/Src/core/cdnfformula.h
+++ b/trunk/Src/core/cdnfformula.h
@@ -10,16 +10,16 @@
 
 typedef vector conjunction, disjunction, monomial;
 
-inline monomial *cdnfformula_monomial_M_DNF (bitvector *bv);
-inline disjunction *cdnfformula_disjunction_new (uscalar_t length);
-inline disjunction *cdnfformula_disjunction_unit (void);
-inline disjunction *cdnfformula_disjunction_add (disjunction *, monomial *);
-inline void cdnfformula_disjunction_free (disjunction *);
-inline disjunction *cdnfformula_conjunction_new (uscalar_t length);
-inline conjunction *cdnfformula_conjunction_unit (void);
-inline conjunction *cdnfformula_conjunction_add (conjunction *, disjunction *);
-inline void cdnfformula_free (conjunction *);
+monomial *cdnfformula_monomial_M_DNF (bitvector *bv);
+disjunction *cdnfformula_disjunction_new (uscalar_t length);
+disjunction *cdnfformula_disjunction_unit (void);
+disjunction *cdnfformula_disjunction_add (disjunction *, monomial *);
+void cdnfformula_disjunction_free (disjunction *);
+disjunction *cdnfformula_conjunction_new (uscalar_t length);
+conjunction *cdnfformula_conjunction_unit (void);
+conjunction *cdnfformula_conjunction_add (conjunction *, disjunction *);
+void cdnfformula_free (conjunction *);
 void cdnfformula_print (conjunction *f);
-inline boolformula_t *cdnfformula_to_boolformula (conjunction *);
+boolformula_t *cdnfformula_to_boolformula (conjunction *);
 bool cdnfformula_eval_M_DNF (disjunction *m_dnf, bitvector *bv);
 #endif

--- a/trunk/Src/core/vector.h
+++ b/trunk/Src/core/vector.h
@@ -19,9 +19,9 @@ typedef struct {
 vector *vector_new (uscalar_t length);
 void vector_free (vector *vec);
 void vector_resize (vector *vec, uscalar_t new_length);
-inline uscalar_t vector_length (vector *vec);
-inline pointer_t vector_get (vector *vec, uscalar_t idx);
-inline void vector_set (vector *vec, uscalar_t idx, pointer_t elt);
-inline void vector_add (vector *vec, pointer_t elt);
+uscalar_t vector_length (vector *vec);
+pointer_t vector_get (vector *vec, uscalar_t idx);
+void vector_set (vector *vec, uscalar_t idx, pointer_t elt);
+void vector_add (vector *vec, pointer_t elt);
 
 #endif


### PR DESCRIPTION
This was done to to eliminate compiler errors on Ubuntu 16.04 and GCC 5.4.